### PR TITLE
Update README to include fsharp mention for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Building under recent Ubuntu with Mono and optional MonoDevelop, goes something 
 ```
 cd CoreTabular 
 #get MS VB dll
-sudo apt-get install libmono-microsoft-visualbasic10.0-cil 
+sudo apt-get install libmono-microsoft-visualbasic10.0-cil fsharp
 sudo apt-get install nuget
 nuget restore
 chmod a+x packages/FsLexYacc.6.1.0/build/fslex.exe 


### PR DESCRIPTION
fsharp required as dependency when building on Ubuntu 19.10